### PR TITLE
src/testing: fix the link #hdr-Description_of_testing_flags

### DIFF
--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -34,7 +34,7 @@
 // its -bench flag is provided. Benchmarks are run sequentially.
 //
 // For a description of the testing flags, see
-// https://golang.org/cmd/go/#hdr-Description_of_testing_flags.
+// https://golang.org/cmd/go/#hdr-Testing_flags
 //
 // A sample benchmark function looks like this:
 //     func BenchmarkHello(b *testing.B) {


### PR DESCRIPTION
Fixed a broken link to a section in the documentation for the test flags for the go command  (#hdr-Description_of_testing_flags -> #hdr-Testing_flags).
